### PR TITLE
docs: modernize ubuntu from bionic to jammy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,25 +10,35 @@ Each branch contains configuration specific for each platform. The Dockerfile ca
 
 (requires Docker to be installed)
 
-1. Pull docker image of QRL node in Ubuntu 18.04 container:
+1. Pull docker image of QRL node in Ubuntu 22.04 container:
 
-    ``docker pull qrledger/qrl-docker:bionic``
+    ```bash
+    docker pull qrledger/qrl-docker:jammy
+    ```
 
-2. Run a detached container:
+2. Run a detached container, may need this arg [--platform linux/{amd64,arm64}]:
 
-    ``docker run -d --name=qrl-node qrledger/qrl-docker:bionic``
+    ```bash
+    docker run -d --name=qrl-node qrledger/qrl-docker:jammy
+    ```
 
 3. Start the node:
 
-    ``docker start qrl-node``
+    ```bash
+    docker start qrl-node
+    ```
 
 4. See the console logs:
 
-    ``docker logs qrl-node``
+    ```bash
+    docker logs qrl-node
+    ```
 
 5. Generate an encrypted wallet (-i and -t flags to interact with terminal)
 
-    ``docker exec -i -t qrl-node qrl wallet_gen --encrypt``
+    ```bash
+    docker exec -i -t qrl-node qrl wallet_gen --encrypt
+    ```
 
 ## Docker desktop
 


### PR DESCRIPTION
This pull request updates the Docker instructions in the `README.md` file to reflect the new Ubuntu version used for the QRL node Docker image. The most important change is the update from Ubuntu 18.04 (bionic) to Ubuntu 22.04 (jammy).

Updates to Docker instructions:

* Changed the Docker image pull command to use `qrledger/qrl-docker:jammy` instead of `qrledger/qrl-docker:bionic`.
* Updated the Docker run command to use the new image tag `jammy` and added a note about the `--platform` argument for different architectures.
* And added code blocks